### PR TITLE
Add diffs field with number of changes into merge request info

### DIFF
--- a/test-requirements.in
+++ b/test-requirements.in
@@ -1,1 +1,2 @@
 pytest
+requests_mock

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,10 +4,17 @@
 #
 #    pip-compile --output-file test-requirements.txt test-requirements.in
 #
-atomicwrites==1.2.1       # via pytest
-attrs==18.2.0             # via pytest
-more-itertools==4.3.0     # via pytest
-pluggy==0.8.0             # via pytest
-py==1.7.0                 # via pytest
-pytest==4.0.0
-six==1.11.0               # via more-itertools, pytest
+atomicwrites==1.3.0       # via pytest
+attrs==19.1.0             # via pytest
+certifi==2019.3.9         # via requests
+chardet==3.0.4            # via requests
+idna==2.8                 # via requests
+more-itertools==7.0.0     # via pytest
+pluggy==0.11.0            # via pytest
+py==1.8.0                 # via pytest
+pytest==4.5.0
+requests-mock==1.6.0
+requests==2.22.0          # via requests-mock
+six==1.12.0               # via pytest, requests-mock
+urllib3==1.25.2           # via requests
+wcwidth==0.1.7            # via pytest

--- a/unfurl_message.py
+++ b/unfurl_message.py
@@ -186,6 +186,7 @@ def get_merge_requests_info(session, path_info):
             assignee = format_user(data["assignee"], warn_blocked=True)
         milestone = data["milestone"]
         state = data["state"]
+        diffs = data["changes_count"]
     except IndexError as e:
         log.exception("Error in data from GitLab")
         raise
@@ -194,6 +195,10 @@ def get_merge_requests_info(session, path_info):
         title += f" ({state})"
 
     fields = [{"title": "Assignee", "value": assignee, "short": "true"}]
+    if diffs:
+        fields.append(
+            {"title": "Diffs", "value": diffs, "short": "true"}
+        )
 
     if milestone:
         fields.append(


### PR DESCRIPTION
This commit adds new field with number of changes, if appropriate
field is available in Gitlab API.

Also it adds tests for MR info.